### PR TITLE
Allow bun executable to be set by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://github.com/z0rzi/ai-chat.nvim/assets/22566633/c0e2f6bf-9cae-4665-82a1-3d
 
 This plugin is written in LUA for the interface part, and in TypeScript for the communication with copilot.
 
-It is shipped with a typescript runtime (`bun`), and does not have any dependency, so you don't have to worry about installing anything.
+It is shipped with a typescript runtime (`bun`) for Linux. For other operating systems, either make sure the `bun` runtime is in your `$PATH` or specify an executable path using `bun_executable` in the config.
 
 ## ⚠️ Disclaimer ⚠️
 
@@ -45,6 +45,7 @@ Default configuration:
     prev_hunk = '[[',
     reset_chat = '<C-d>'
   },
+  bun_executable = nil,
 
   files = {
     chat_file = os.getenv("HOME") .. '/.config/ai-chat/chat.md',
@@ -59,6 +60,8 @@ Keymaps:
 
 - `<LEADER>m` in normal mode to open the chat.
 - `<LEADER>m` in visual mode to send the current text to the chat. All previous messages in the chat will be erased by default.
+- `<LEADER>a` sends the current user message to copilot.
+- `<LEADER>d` clears the prompt.
 
 ## Macros
 

--- a/lua/ai-chat.lua
+++ b/lua/ai-chat.lua
@@ -15,6 +15,7 @@ M.config = {
     prev_hunk = '[[',
     reset_chat = '<C-d>'
   },
+  bun_executable = nil,
 
   files = {
     chat_file = os.getenv("HOME") .. '/.config/ai-chat/chat.md',
@@ -23,21 +24,24 @@ M.config = {
 }
 
 local function script_path()
-  local str = debug.getinfo(2, "S").source:sub(2)
-  return str:match("(.*/)")
+  local script = debug.getinfo(2, "S").source:sub(2)
+  local dir_path = script:match("(.*/)")
+  -- if there is no executable or bun_executable in the config, we will use the shipped bun executable
+  local bun_path = string.format("%s ", vim.fn.exepath("bun") or M.config.bun_executable or "")
+  return string.format("%s%scopilot/index.ts ", bun_path, dir_path)
 end
 
 local function run_copilot_script(args)
   local path = script_path()
 
   if M.gh_device_code ~= nil then
-    local handle = io.popen(path .. "/copilot/index.ts connect " .. M.gh_device_code)
+    local handle = io.popen(path .. "connect " .. M.gh_device_code)
     local result = handle:read("*a")
     handle:close()
     M.gh_device_code = nil
   end
   
-  local handle = io.popen(path .. "/copilot/index.ts " .. args)
+  local handle = io.popen(path .. args)
   local result = handle:read("*a")
   handle:close()
 
@@ -292,7 +296,7 @@ function M.run_macro(start_line, end_line)
   file:close()
 
   local path = script_path()
-  local handle = io.popen(path .. "/copilot/index.ts macro " .. file_path .. " " .. code_file_path)
+  local handle = io.popen(path .. "macro " .. file_path .. " " .. code_file_path)
   local result = handle:read("*a")
   handle:close()
 


### PR DESCRIPTION
Hi @z0rzi, thanks for making this plugin! I tried it out today but unfortunately I wasn't able to make it work out of the box. After some debugging, I found that the executable that's included is for Linux. Running `file ./lua/copilot/bun` gave me: `./lua/copilot/bun: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[xxHash]=f0cd378df2f73266, stripped`

I've added some code here that should solve the issue for any other users. It allows the bun executable path to be either set in the config or found on the `$PATH`, but Linux users can still use the shipped executable out of the box. I've tested it out and it seems to be working well.

I also updated the readme with this information and added a few missing keymaps.